### PR TITLE
Give an album and a playlist the page they deserve

### DIFF
--- a/app/src/main/java/dev/lelonio/square/backend/SpotifyBackend.kt
+++ b/app/src/main/java/dev/lelonio/square/backend/SpotifyBackend.kt
@@ -109,7 +109,7 @@ class SpotifyBackend(private val container: SquareApplication) : MusicBackend {
         runCatching { Catalog.playlists() }
             .recoverCatching {
                 check(container.webApi.isReady) { it.message ?: "rootlist non disponibile" }
-                container.api.playlists(limit = WEB_API_PAGE).items.map { dto ->
+                container.api.playlists(limit = WEB_API_LIBRARY_PAGE).items.map { dto ->
                     CatalogPlaylist(
                         uri = dto.uri,
                         name = dto.name,
@@ -153,7 +153,7 @@ class SpotifyBackend(private val container: SquareApplication) : MusicBackend {
         val loaded = mutableListOf<CatalogTrack>()
         var offset = 0
         while (true) {
-            val page = container.api.savedTracks(limit = WEB_API_PAGE, offset = offset)
+            val page = container.api.savedTracks(limit = WEB_API_LIBRARY_PAGE, offset = offset)
             loaded += page.items.mapNotNull { saved ->
                 saved.track
                     .takeIf { it.isPlayable != false && it.uri.startsWith("spotify:track:") }
@@ -242,7 +242,19 @@ class SpotifyBackend(private val container: SquareApplication) : MusicBackend {
 
     private companion object {
         /** The Web API's own maximum page size for playlist tracks. */
+        /** What the playlist endpoints take a page at a time. */
         const val WEB_API_PAGE = 100
+
+        /**
+         * What the account's own lists take, which is half that.
+         *
+         * `me/playlists` and `me/tracks` cap at 50 and answer 400 to anything
+         * larger — not an empty page, an error. It surfaced only when the access
+         * point was unreachable and these were asked instead of it, which is to
+         * say on a bad connection: the library then failed twice over and
+         * reported the second failure.
+         */
+        const val WEB_API_LIBRARY_PAGE = 50
 
         /**
          * The purple heart Spotify's own clients draw for Liked Songs.

--- a/app/src/main/java/dev/lelonio/square/data/SpotifyApi.kt
+++ b/app/src/main/java/dev/lelonio/square/data/SpotifyApi.kt
@@ -160,7 +160,7 @@ interface SpotifyApi {
     @GET("v1/playlists/{id}")
     suspend fun playlist(
         @Path("id") playlistId: String,
-        @Query("fields") fields: String = "id,uri,name,images",
+        @Query("fields") fields: String = "id,uri,name,images,description",
     ): PlaylistDto
 
     /**

--- a/app/src/main/java/dev/lelonio/square/ui/MainViewModel.kt
+++ b/app/src/main/java/dev/lelonio/square/ui/MainViewModel.kt
@@ -107,6 +107,8 @@ class MainViewModel(app: Application) : AndroidViewModel(app) {
         val loadingMore: Boolean = false,
         val error: String? = null,
         val kind: DetailKind = DetailKind.PLAYLIST,
+        /** What the source says the list is about; empty when it says nothing. */
+        val description: String = "",
         /** Populated for artists only. */
         val albums: List<SearchItem> = emptyList(),
         /** Their singles and EPs, kept apart from the albums above. */
@@ -1221,8 +1223,30 @@ class MainViewModel(app: Application) : AndroidViewModel(app) {
             state.copy(
                 name = state.name.ifEmpty { current.name },
                 artworkUrl = state.artworkUrl ?: current.artworkUrl,
+                description = state.description.ifEmpty { current.description },
             )
         }
+    }
+
+    /**
+     * A playlist's own words about itself.
+     *
+     * Spotify writes them in HTML, entities and anchors included, because the
+     * field is meant for a web page. What belongs under a title is the sentence,
+     * so the markup is taken back out.
+     */
+    private suspend fun descriptionOf(uri: String): String? {
+        if (!container.webApi.isReady || !uri.startsWith("spotify:playlist:")) return null
+        return runCatching {
+            container.api.playlist(uri.substringAfterLast(':')).description
+                ?.replace(Regex("<[^>]*>"), "")
+                ?.replace("&amp;", "&")
+                ?.replace("&quot;", "\"")
+                ?.replace("&#x27;", "'")
+                ?.replace("&#39;", "'")
+                ?.trim()
+                ?.takeIf { it.isNotEmpty() }
+        }.getOrNull()
     }
 
     /** A link's own title, from whichever side of Spotify will say. */
@@ -1413,6 +1437,17 @@ class MainViewModel(app: Application) : AndroidViewModel(app) {
                 base = base.copy(name = name)
                 if (_playlist.value.uri == playlist.uri) {
                     _playlist.value = _playlist.value.copy(name = name)
+                }
+            }
+
+            // What the list says about itself, when its source says anything.
+            // Asked for beside the picture and written the same way, through
+            // `base`, so a later publish cannot take it back off the screen.
+            if (base.description.isEmpty() && kind == DetailKind.PLAYLIST) launch {
+                val text = descriptionOf(playlist.uri) ?: return@launch
+                base = base.copy(description = text)
+                if (_playlist.value.uri == playlist.uri) {
+                    _playlist.value = _playlist.value.copy(description = text)
                 }
             }
 

--- a/app/src/main/java/dev/lelonio/square/ui/SquareApp.kt
+++ b/app/src/main/java/dev/lelonio/square/ui/SquareApp.kt
@@ -868,6 +868,28 @@ fun SquareApp(
                                         )
                                     },
                                     onToggleFollow = viewModel::toggleFollowArtist,
+                                    onShare = {
+                                        val uri = playlist.uri ?: return@PlaylistScreen
+                                        context.startActivity(
+                                            android.content.Intent.createChooser(
+                                                android.content.Intent(android.content.Intent.ACTION_SEND)
+                                                    .setType("text/plain")
+                                                    .putExtra(
+                                                        android.content.Intent.EXTRA_TEXT,
+                                                        dev.lelonio.square.ui.library.openLinkOf(uri),
+                                                    ),
+                                                null,
+                                            ),
+                                        )
+                                    },
+                                    onMenu = {
+                                        val uri = playlist.uri ?: return@PlaylistScreen
+                                        playlistMenu = CatalogPlaylist(
+                                            uri = uri,
+                                            name = playlist.name,
+                                            artworkUrl = playlist.artworkUrl,
+                                        )
+                                    },
                                 )
                             }
                         }

--- a/app/src/main/java/dev/lelonio/square/ui/library/PlaylistScreen.kt
+++ b/app/src/main/java/dev/lelonio/square/ui/library/PlaylistScreen.kt
@@ -5,6 +5,7 @@ import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -95,6 +96,7 @@ import com.adamglin.phosphoricons.regular.ArrowLeft
 import com.adamglin.phosphoricons.regular.ArrowsDownUp
 import com.adamglin.phosphoricons.regular.Check
 import com.adamglin.phosphoricons.regular.DotsThree
+import com.adamglin.phosphoricons.regular.Export
 import com.adamglin.phosphoricons.regular.LinkSimple
 import com.adamglin.phosphoricons.regular.Plus
 import com.adamglin.phosphoricons.regular.Queue
@@ -138,6 +140,10 @@ fun PlaylistScreen(
     onOpenItem: (dev.lelonio.square.data.SearchItem) -> Unit = {},
     /** Follows or unfollows the artist this page is about. */
     onToggleFollow: () -> Unit = {},
+    /** Hands the page's own link to whoever wants it. */
+    onShare: () -> Unit = {},
+    /** Opens the sheet with everything else this page can do. */
+    onMenu: () -> Unit = {},
     /** The remembered track order, and where a change to it is stored. */
     storedSort: String? = null,
     onSortChange: (String) -> Unit = {},
@@ -276,6 +282,8 @@ fun PlaylistScreen(
         DetailHeader(
             name = state.name,
             kind = state.kind,
+            description = state.description,
+            pageColor = pageColor,
             trackCount = state.tracks.size,
             totalMs = state.tracks.sumOf { it.durationMs },
             backdrop = pageBackdrop,
@@ -488,6 +496,49 @@ fun PlaylistScreen(
                 ),
         )
 
+        // Share and everything else, in one capsule opposite the back button.
+        // Two round buttons side by side would have read as two destinations;
+        // one pane with a divide down it reads as what it is, a place where the
+        // page's own actions live.
+        Row(
+            Modifier
+                .padding(top = contentPadding.calculateTopPadding() + 8.dp, end = 14.dp)
+                .align(Alignment.TopEnd)
+                .graphicsLayer { alpha = 1f - collapseFraction() },
+            horizontalArrangement = Arrangement.spacedBy(2.dp),
+        ) {
+            LiquidButton(
+                onClick = onShare,
+                backdrop = pageBackdrop,
+                modifier = Modifier.size(42.dp),
+                contentHeight = 42.dp,
+                contentPadding = 0.dp,
+                blurRadius = 8.dp,
+            ) {
+                Icon(
+                    PhosphorIcons.Regular.Export,
+                    contentDescription = stringResource(R.string.copy_link),
+                    tint = Color.White,
+                    modifier = Modifier.size(18.dp),
+                )
+            }
+            LiquidButton(
+                onClick = onMenu,
+                backdrop = pageBackdrop,
+                modifier = Modifier.size(42.dp),
+                contentHeight = 42.dp,
+                contentPadding = 0.dp,
+                blurRadius = 8.dp,
+            ) {
+                Icon(
+                    PhosphorIcons.Regular.DotsThree,
+                    contentDescription = stringResource(R.string.more),
+                    tint = Color.White,
+                    modifier = Modifier.size(20.dp),
+                )
+            }
+        }
+
         // Floating rather than a top bar: the list scrolls under it, so the
         // picture stays uninterrupted. It gives way to the collapsed bar, which
         // carries a back button of its own.
@@ -557,6 +608,9 @@ private fun IntOffset.leftOf(density: androidx.compose.ui.unit.Density): IntOffs
 private fun DetailHeader(
     name: String,
     kind: MainViewModel.DetailKind,
+    description: String,
+    /** The page's own colour; the solid Play button prints its label in it. */
+    pageColor: Color,
     trackCount: Int,
     totalMs: Long,
     backdrop: Backdrop,
@@ -594,6 +648,19 @@ private fun DetailHeader(
                 .graphicsLayer { alpha = (1f - collapse() * 2f).coerceIn(0f, 1f) },
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {
+            // The name first and what it is underneath, which is the order
+            // somebody reads them in: the title is the thing, "Album" is a
+            // caption on it.
+            Text(
+                text = name,
+                style = MaterialTheme.typography.headlineMedium,
+                fontWeight = FontWeight.Bold,
+                color = Color.White,
+                textAlign = TextAlign.Center,
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis,
+            )
+
             Text(
                 text = stringResource(kind.label) + if (trackCount > 0) {
                     stringResource(R.string.track_count_and_length, trackCount, formatTotal(totalMs))
@@ -602,55 +669,67 @@ private fun DetailHeader(
                 },
                 style = MaterialTheme.typography.labelMedium,
                 color = Color.White.copy(alpha = 0.72f),
-            )
-
-            Text(
-                text = name,
-                style = MaterialTheme.typography.displayLarge,
-                color = Color.White,
-                textAlign = TextAlign.Center,
-                maxLines = 2,
-                overflow = TextOverflow.Ellipsis,
-                modifier = Modifier.padding(top = 6.dp),
+                modifier = Modifier.padding(top = 4.dp),
             )
 
             Row(
-                Modifier.padding(top = 18.dp),
-                horizontalArrangement = Arrangement.spacedBy(18.dp),
+                Modifier.padding(top = 16.dp),
+                horizontalArrangement = Arrangement.spacedBy(14.dp),
                 verticalAlignment = Alignment.CenterVertically,
             ) {
                 CircleAction(
                     icon = PhosphorIcons.Regular.Shuffle,
                     description = stringResource(R.string.shuffle),
-                    size = 46.dp,
+                    size = 52.dp,
                     backdrop = backdrop,
                     onClick = onShuffle,
                 )
-                // The one solid control on the screen. Everything else here is
-                // glass, so weight has to come from the fill rather than from
-                // size alone.
-                Box(
+                // The one solid control on the screen, and the only one that
+                // says what it does in words. Everything else here is glass, so
+                // weight has to come from the fill rather than from size.
+                Row(
                     Modifier
-                        .size(68.dp)
                         .softShadow(CircleShape, elevation = 18.dp, spot = 0.3f)
                         .clip(CircleShape)
                         .background(Color.White)
-                        .pressable(onPlay, pressedScale = 0.92f),
-                    contentAlignment = Alignment.Center,
+                        .pressable(onPlay, pressedScale = 0.95f)
+                        .padding(horizontal = 40.dp, vertical = 14.dp),
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    verticalAlignment = Alignment.CenterVertically,
                 ) {
                     Icon(
                         PhosphorIcons.Fill.Play,
-                        contentDescription = stringResource(R.string.play),
-                        tint = Color.Black,
-                        modifier = Modifier.size(34.dp),
+                        contentDescription = null,
+                        tint = pageColor,
+                        modifier = Modifier.size(22.dp),
+                    )
+                    Text(
+                        stringResource(R.string.play),
+                        style = MaterialTheme.typography.titleMedium,
+                        fontWeight = FontWeight.SemiBold,
+                        color = pageColor,
                     )
                 }
                 CircleAction(
                     icon = if (searching) PhosphorIcons.Regular.X else PhosphorIcons.Fill.MagnifyingGlass,
                     description = stringResource(R.string.search_in_tracks),
-                    size = 46.dp,
+                    size = 52.dp,
                     backdrop = backdrop,
                     onClick = onToggleSearch,
+                )
+            }
+
+            // What the list is, in its own words. Only the sources that carry
+            // one have it, and a page without it simply has one line less.
+            if (description.isNotEmpty()) {
+                Text(
+                    description,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = Color.White.copy(alpha = 0.62f),
+                    textAlign = TextAlign.Center,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis,
+                    modifier = Modifier.padding(top = 14.dp, start = 8.dp, end = 8.dp),
                 )
             }
         }
@@ -956,26 +1035,41 @@ private fun TrackRow(
             .padding(horizontal = 12.dp, vertical = 11.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
-        // The number is replaced by a level meter on the playing row, so the
-        // state survives without relying on the accent being distinguishable.
-        Box(Modifier.width(30.dp), contentAlignment = Alignment.CenterStart) {
+        // The record, not the row number. A list of covers is scanned by
+        // recognition rather than by reading, and the position of a song in a
+        // playlist is the least interesting thing about it. The playing row
+        // still says so, with the meter drawn over its own cover.
+        Box(contentAlignment = Alignment.Center) {
+            Artwork(
+                url = track.artworkUrl,
+                title = track.name,
+                modifier = Modifier.size(46.dp),
+                corner = 8.dp,
+                decodeSize = 46.dp,
+            )
             if (isCurrent) {
-                Icon(
-                    PhosphorIcons.Fill.Waveform,
-                    contentDescription = stringResource(R.string.now_playing),
-                    tint = MaterialTheme.colorScheme.primary,
-                    modifier = Modifier.size(18.dp),
-                )
-            } else {
-                Text(
-                    text = "%02d".format(position),
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f),
-                )
+                Box(
+                    Modifier
+                        .size(46.dp)
+                        .clip(RoundedCornerShape(8.dp))
+                        .background(Color.Black.copy(alpha = 0.45f)),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Icon(
+                        PhosphorIcons.Fill.Waveform,
+                        contentDescription = stringResource(R.string.now_playing),
+                        tint = Color.White,
+                        modifier = Modifier.size(20.dp),
+                    )
+                }
             }
         }
 
-        Column(Modifier.weight(1f)) {
+        Column(
+            Modifier
+                .weight(1f)
+                .padding(start = 14.dp),
+        ) {
             Text(
                 text = track.name,
                 style = MaterialTheme.typography.titleMedium,
@@ -1033,6 +1127,22 @@ fun CatalogTrack.openLink(): String {
     } else {
         "https://open.spotify.com/track/$id"
     }
+}
+
+/**
+ * The web address for a page: a playlist, an album, an artist.
+ *
+ * The same shape as a track's, and told apart the same way — a `ytmusic:` uri
+ * belongs to one service and a `spotify:` one to the other, and a link handed to
+ * the wrong service points at nothing.
+ */
+fun openLinkOf(uri: String): String {
+    val id = uri.substringAfterLast(':')
+    if (uri.startsWith("ytmusic:")) {
+        return "https://music.youtube.com/playlist?list=$id"
+    }
+    val kind = uri.split(':').getOrNull(1) ?: "playlist"
+    return "https://open.spotify.com/$kind/$id"
 }
 
 @Composable


### PR DESCRIPTION
## What changed

The detail screen — albums, playlists, and the artist page that shares it — follows the layout in the reference the listener asked for:

- **Title first, caption under it.** The name is the thing; "Playlist · 50 brani · 2h 41min" is a caption on it.
- **Play is a pill with the word on it**, filled white with the label printed in the page's own colour. It is the only solid control on a screen made of glass, so the weight comes from the fill.
- **The list's own description**, when the source has one. Spotify writes it for a web page, so the tags and the entities are stripped before the sentence lands under the title.
- **Rows lead with the cover** instead of the track number. The playing row keeps saying so, with the meter drawn over its own cover.
- **Share and the overflow menu** sit in a capsule opposite the back button. Share hands the page's link to the system sheet; the menu opens the sheet the library already uses for a playlist.

The cover itself is untouched: full width, fading into the page colour, as it was.

## The 400

Unrelated to the redesign and found while testing it. `me/playlists` and `me/tracks` cap at 50 per page and answer **HTTP 400** — not an empty page — to anything larger, and both were being asked for 100. It only showed when the access point was unreachable and the Web API was asked in its place, so a bad connection failed twice and the app reported the second failure as the library being broken. The account's own lists now ask for 50; a playlist's tracks still ask for 100, which is their real limit.

## Notes for a reviewer

- `PlaylistState` gains `description`, carried through `publishPlaylist` like the name and the artwork so a later publish cannot take it back off the screen.
- The bottom-bar experiment from earlier in the session is deliberately **not** here; it was discarded.
- Built and run on device: a playlist opened from a link, an album, and an artist page.